### PR TITLE
Testbed setup: Add a bunch of scripts to setup cpu virtual machines (m4.xlarge), sriov, eswitch, and offloaded ovs

### DIFF
--- a/scripts/testbed/enable_eswitch.sh
+++ b/scripts/testbed/enable_eswitch.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -e
+
+if [ $UID -ne 0 ]; then
+	echo "Please run $0 as root"
+	exit 3
+fi
+
+if [ $# -ne 1 ]; then
+	echo "Usage: $0 <pf_intf>"
+	exit 1
+fi
+
+pf=$1
+
+pci_addr=$(basename `readlink /sys/class/net/$pf/device`)
+echo "PCI address of $pf is $pci_addr"
+
+pci_bus=$(printf "%d" "0x`echo $pci_addr | cut -d':' -f2`")
+pci_slot=$(printf "%d" "0x`echo $pci_addr | cut -d':' -f3 | cut -d'.' -f1 `")
+pf_altname="enp${pci_bus}s${pci_slot}"
+echo "altname of PF: $pf_altname"
+
+# check if device has already been set to eswitch mode
+mode=`cat /sys/class/net/$pf/compat/devlink/mode`
+if [ $mode = "switchmode" ]; then
+	echo "$pf has already been set to eswitch mode"
+	exit 2
+fi
+
+# unbind the VFs
+num_vfs=`cat /sys/class/net/$pf/device/sriov_numvfs`
+drivers=(`seq 1 8`)
+
+for ((i=0;i<$num_vfs;i++)); do
+	vf_pci_addr=$(basename `readlink /sys/class/net/$pf/device/virtfn$i`)
+	driver=$(basename `readlink /sys/bus/pci/devices/$vf_pci_addr/driver`)
+	drivers[$i]=$driver
+	echo $vf_pci_addr > /sys/bus/pci/devices/$vf_pci_addr/driver/unbind
+	# show results
+	lspci -k -s $vf_pci_addr
+done
+
+echo switchdev > "/sys/class/net/$pf/compat/devlink/mode"
+
+echo "sleeping for 20 seconds..."
+sleep 20
+
+# check if the VF representors has been renamed
+ip link
+
+# It is necessary to first set the network VF representor device names
+# to be in the form of $PF_$VFID where $PF is the PF netdev name,
+# and $VFID is the VF ID=0,1,[..], bring up these VF representors
+for ((i=0;i<$num_vfs;i++)); do
+	ip link set "${pf_altname}_${i}" name "${pf}_${i}"
+	ip link set "${pf}_${i}" up
+done
+
+
+# re-bind the VFs' drivers
+for ((i=0;i<$num_vfs;i++)); do
+	vf_pci_addr=$(basename `readlink /sys/class/net/$pf/device/virtfn$i`)
+	echo $vf_pci_addr > /sys/bus/pci/drivers/${drivers[$i]}/bind
+	# show results
+	lspci -k -s $vf_pci_addr
+done

--- a/scripts/testbed/enable_sriov.sh
+++ b/scripts/testbed/enable_sriov.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e
+
+if [ $UID -ne 0 ]; then
+	echo "Please run $0 as root"
+	exit 3
+fi
+
+if [ $# -ne 2 ]; then
+	echo "Usage: $0 <pf_intf> <num_vfs>"
+	exit 1
+fi
+
+pf=$1
+num_vfs=$2
+
+pci_addr=$(basename `readlink /sys/class/net/$pf/device`)
+echo "PCI address of $pf is $pci_addr"
+# domain:bus:slot.function
+# pci_slot=`echo $pci_addr | cut -d "." -f1`
+
+# check if sriov has already been enabled
+echo 0 > /sys/class/net/$pf/device/sriov_numvfs
+num=`cat /sys/class/net/$pf/device/sriov_numvfs`
+if [ $num -ne 0 ]; then
+	echo "$pf SR-IOV has already been enabled, to change the number of VFs, please disable it first, then execute this script"
+	exit 2
+fi
+
+echo $num_vfs > /sys/class/net/$pf/device/sriov_numvfs
+
+# set mac address of VFs
+for ((i=0;i<$num_vfs;i++)); do
+	macaddr=`tr -dc A-F0-9 < /dev/urandom | head -c 10 | sed -r 's/(..)/\1:/g;s/:$//;s/^/02:/'`
+	ip link set $pf vf $i mac $macaddr;
+done
+
+ip link show $pf
+
+# bind VF's driver to vfio-pci
+modprobe vfio-pci
+
+for ((i=0;i<$num_vfs;i++)); do
+	vf_pci_addr=$(basename `readlink /sys/class/net/$pf/device/virtfn$i`)
+	echo $vf_pci_addr > /sys/bus/pci/devices/$vf_pci_addr/driver/unbind
+	numeric_id=`lspci -s $vf_pci_addr -n | cut -d " " -f3 | tr ':' ' '`
+	echo $numeric_id > /sys/bus/pci/drivers/vfio-pci/new_id
+	# show results
+	lspci -k -s $vf_pci_addr
+done

--- a/scripts/testbed/environment/README.md
+++ b/scripts/testbed/environment/README.md
@@ -1,0 +1,58 @@
+# Base Image Preparation
+
+Scripts to prepare a CPU base image file disk.
+
+```bash
+sudo ./cpu_vm_stage1.sh
+#   at the end of stage1, the script will mount the guest filesystem at
+# /mnt, and copy the stage2 script to /mnt/root, and chroot to that and
+# execute the stage2.sh.
+```
+
+To install and use the VM, use libvirt. First copy the `cpu_vm_base.img` to 
+`/var/lib/libvirt/images/cpu_vm_base.img`. Then run virt-install. The
+example below create a AWS `m4.xlarge` like CPU machine, except that the
+network uses RDMA SR-IOV. Remove the `--print-xml` to actually install
+the profile to libvirt.
+```bash
+# you may finish the install without graphics
+virt-install --virt-type kvm --name cpubase --vcpus 4 --ram 16384 --boot hd --disk /var/lib/libvirt/images/cpu_vm_base.img,format=raw --network network=default --hostdev=pci_0000_18_00_1 --nographic --os-type=linux --os-variant=ubuntu20.04 --print-xml
+
+# or with graphics
+virt-install --virt-type kvm --name cpubase --vcpus 4 --ram 16384 --boot hd --disk /var/lib/libvirt/images/cpu_vm_base.img,format=raw --network network=default --hostdev=pci_0000_18_00_1 --graphic vnc,listen=0.0.0.0 --os-type=linux --os-variant=ubuntu20.04 --print-xml
+```
+
+
+To simply the configuration, I use default network created by libvirt to
+allow internet access (SNAT). But this would now allow the VMs to reach
+each other. To allow this, configure correct IP addresses for the rdma
+interface and use that for interconnection. The switch has already been
+configuration to support this.
+
+
+A bunch of things I decide to setup later after all VMs have been booted are that
+1. add many sshkeys to these VMs
+2. generate a script for each VM to bring up and set different IP 
+   address for the rdma interface.
+3. On every boot, attach VFs to corresponding VMs by using virsh 
+   attach-device, this gives more flexibility.
+4. configure the name address resolution in both guests and hosts to
+   allow easy access by sth like rdma0.cpu5
+
+
+Then we are done!
+
+
+### Notes
+A couple of things that has to be check for each reboot of physical
+server (aka what is not persistent).
+1. `enable_sriov.sh`
+2. `enable_eswitch.sh`
+3. `setup_ovs.sh`
+
+The order is important.
+
+To disable eswtich and recovery the configuation.
+1. `echo legacy | sudo tee /sys/class/net/rdma0/compat/devlink/mode`
+2. `enable_sriov.sh`
+3. `echo 0 | sudo tee /sys/class/net/rdma0/device/sriov_numvfs` (optionally)

--- a/scripts/testbed/environment/base_config/interfaces.conf.sh
+++ b/scripts/testbed/environment/base_config/interfaces.conf.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+IP_ADDR_CIDR="$1"
+GATEWAY_ADDR="$2"
+
+if [ $# -ne 2 ]; then
+	echo "Usage: $0 <IP_ADDR_CIDR> <GATEWAY_ADDR>"
+	echo "For example: $0 172.16.0.100/24 172.16.0.160"
+	exit 1
+fi
+
+cat <<EOF
+[Match]
+Name=enp1s0
+
+[Network]
+Address=${IP_ADDR_CIDR}
+Gateway=${GATEWAY_ADDR}
+DNS=152.3.140.31
+DNS=152.3.140.1
+EOF

--- a/scripts/testbed/environment/base_config/set_rdma_intf.conf.sh
+++ b/scripts/testbed/environment/base_config/set_rdma_intf.conf.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+RDMA_IP_ADDR_CIDR="$1"
+
+if [ $# -ne 1 ]; then
+	echo "Usage: $0 <IP_ADDR_CIDR>"
+	echo "For example: $0 1.1.1.1/24"
+	exit 1
+fi
+
+cat <<EOF
+#!/bin/bash
+
+if [ \$# -ne 1 ]; then
+	echo "Usage: \$0 <intf>"
+	exit 1
+fi
+
+intf=\$1
+
+sudo ip link set \$intf name rdma0
+sudo ip link set rdma0 up
+sudo ip addr add ${RDMA_IP_ADDR_CIDR} dev rdma0
+sudo ip link set rdma0 mtu 1430
+EOF

--- a/scripts/testbed/environment/cpu_vm_stage1.sh
+++ b/scripts/testbed/environment/cpu_vm_stage1.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# This script will create cpu_vm_base.img in the current directory,
+# the cpu_vm_base.img can be used as a disk and boot by qemu
+
+DISK_IMG=/tmp/cpu_vm_base.img
+
+umount /mnt
+losetup -D
+
+# create raw disk, the 5GB is not enought for the latest OFED packages, so give it 10GB
+dd if=/dev/zero of=$DISK_IMG bs=1G count=10 status=progress && sync
+
+# create only 1 partition, mark it bootable
+# an example command
+echo -en 'n\np\n1\n\n\na\nw\n\n' | fdisk $DISK_IMG
+
+# in the below example output, I only create 100MB file disk
+# cjr@cpu22 /tmp % fdisk -l raw_disk.img
+# Disk raw.bin: 100 MiB, 104857600 bytes, 204800 sectors
+# Units: sectors of 1 * 512 = 512 bytes
+# Sector size (logical/physical): 512 bytes / 512 bytes
+# I/O size (minimum/optimal): 512 bytes / 512 bytes
+# Disklabel type: dos
+# Disk identifier: 0x7bcdb498
+# 
+# Device     Boot Start    End Sectors Size Id Type
+# raw.bin1   *     2048 204799  202752  99M 83 Linux 
+
+LOOP_DEV=`losetup -f`
+if [ $? -ne 0 ]; then
+	echo "losetup -f cannot find free loop device"
+	exit 1
+fi
+
+losetup $LOOP_DEV $DISK_IMG
+partprobe $LOOP_DEV
+# root@cpu21 /tmp # lsblk
+# NAME      MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
+# loop0       7:0    0  4.7G  0 loop
+# ├─loop0p1 259:0    0  4.7G  0 loop
+# sda         8:0    0  1.8T  0 disk
+# └─sda1      8:1    0  1.8T  0 part /
+
+LOOP_PART=${LOOP_DEV}p1
+# format the filesystems
+mkfs.ext4 $LOOP_PART
+
+# mount the partitions
+mount $LOOP_PART /mnt
+
+# debootstrap
+apt install debootstrap -y
+debootstrap --merged-usr --keyring=/usr/share/keyrings/ubuntu-archive-keyring.gpg --verbose focal /mnt http://archive.ubuntu.com/ubuntu/
+
+# generate fstab
+apt install arch-install-scripts -y
+genfstab -U /mnt | grep -v swap >> /mnt/etc/fstab
+
+# after command finish, chroot to that directory
+cp /etc/apt/sources.list /mnt/etc/apt/sources.list
+
+#mount -t proc /proc /mnt/proc
+#mount --rbind /sys /mnt/sys
+#mount --rbind /dev /mnt/dev
+#mount --rbind /run /mnt/run
+#cp /etc/resolv.conf /mnt/etc/resolv.conf
+#chroot /mnt /bin/bash
+
+cp ./cpu_vm_stage2.sh /mnt/root
+arch-chroot /mnt /bin/bash /root/cpu_vm_stage2.sh $LOOP_DEV
+
+sync
+umount /mnt
+losetup -D

--- a/scripts/testbed/environment/cpu_vm_stage2.sh
+++ b/scripts/testbed/environment/cpu_vm_stage2.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+# copy this to the guest vm filesystem, e.g. /root, and execute it
+
+# =================Second Stage======================
+# after above command, we are able to enter the disk image
+cd /root
+
+[[ $# -ge 1 ]] && LOOP_DEV=$1 || LOOP_DEV=/dev/loop0
+
+# check network connection
+ping -c 1 8.8.8.8
+ping -c 1 google.com
+
+# no need to set keyboard because we use the default
+
+# set hostname
+echo cpuvm > /etc/hostname
+
+# set timezone
+ln -sf /usr/share/zoneinfo/America/New_York /etc/localtime
+
+## set hardware clock sync
+#hwclock --systohc
+#
+## set timedatectl
+#timedatectl set-ntp true
+#timedatectl set-timezone America/New_York
+
+# generate locales
+cat >> /etc/locale.gen <<EOF
+en_US.UTF-8 UTF-8
+zh_CN GB2312
+zh_CN.GB18030 GB18030
+zh_CN.GBK GBK
+zh_CN.UTF-8 UTF-8
+zh_HK BIG5-HKSCS
+zh_HK.UTF-8 UTF-8
+zh_SG GB2312
+zh_SG.GBK GBK
+zh_SG.UTF-8 UTF-8
+zh_TW BIG5
+zh_TW.EUC-TW EUC-TW
+EOF
+
+locale-gen
+
+# update softwares
+apt update
+DEBIAN_FRONTEND=noninteractive apt dist-upgrade -y
+
+# set root passwd
+# stop here and set your password
+echo -ne 'root\nroot\n' | passwd root
+
+# setup kernel and bootloader, this should automatically install bootloader (grub-pc)
+# but need user to choose the disk, so we install it manually later
+KERN_VERSION="5.8.0-36-generic"
+DEBIAN_FRONTEND=noninteractive apt install linux-image-$KERN_VERSION linux-headers-$KERN_VERSION -y
+
+# change grub settings
+mkdir -p /etc/default/grub.d/
+cat > /etc/default/grub.d/50-grub-console.cfg <<EOF
+# Set the recordfail timeout
+GRUB_RECORDFAIL_TIMEOUT=0
+
+# Set the default commandline
+GRUB_CMDLINE_LINUX_DEFAULT="console=tty1 console=ttyS0,115200n8 nosplash"
+
+# Set the grub console type
+GRUB_TERMINAL=serial
+GRUB_SERIAL_COMMAND="serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"
+EOF
+cat > /etc/default/grub.d/51-no-os-prober.cfg <<EOF
+GRUB_DISABLE_OS_PROBER=true
+EOF
+
+update-grub
+grub-install --boot-directory=/boot --recheck --target=i386-pc $LOOP_DEV
+
+# create user and install tools
+apt install wget -y
+wget https://cjr.host/download/config/deploy_maas_master.tar
+mkdir deploy_maas
+tar xf deploy_maas_master.tar -C deploy_maas
+cd deploy_maas
+sed -i 's/NEW_USER=cjr/NEW_USER=tenant/g' deploy.sh
+echo 'tenant' > passfile
+
+# let's start install
+./deploy.sh
+# MLNX_OFED for Ubuntu should be installed with the following flags in chroot environment:
+# ./install_ofed.sh --without-dkms --add-kernel-support --kernel $KERN_VERSION --without-fw-update --force
+# ./install_ofed.sh --without-dkms --kernel $KERN_VERSION --without-fw-update --force
+# they are not working, so install later in the VM, with only --force option.
+
+# remember to enable systemd-networkd.service
+mkdir -p /etc/systemd/system
+mkdir -p /etc/systemd/system/network-online.target.wants
+mkdir -p /etc/systemd/system/sockets.target.wants
+ln -sf /lib/systemd/system/systemd-networkd.service /etc/systemd/system/dbus-org.freedesktop.network1.service
+ln -sf /lib/systemd/system/systemd-networkd.service /etc/systemd/system/multi-user.target.wants/systemd-networkd.service
+ln -sf /lib/systemd/system/systemd-networkd.socket /etc/systemd/system/sockets.target.wants/systemd-networkd.socket
+ln -sf /lib/systemd/system/systemd-networkd-wait-online.service /etc/systemd/system/network-online.target.wants/systemd-networkd-wait-online.service
+
+# also enable tmpfs at /tmp
+mkdir -p /etc/systemd/system/local-fs.target.wants
+cp /usr/share/systemd/tmp.mount /etc/systemd/system/
+ln -sf /etc/systemd/system/tmp.mount /etc/systemd/system/local-fs.target.wants/tmp.mount
+
+cat > /etc/systemd/network/20-mgmt.network <<EOF
+[Match]
+Name=enp1s0
+
+[Network]
+DHCP=ipv4
+EOF
+
+
+# sync the disk
+sync
+
+exit

--- a/scripts/testbed/setup_ovs.sh
+++ b/scripts/testbed/setup_ovs.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+
+if [ $UID -ne 0 ]; then
+	echo "Please run $0 as root"
+	exit 3
+fi
+
+# Create an OVS bridge (here it's named ovs-sriov).
+ovs-vsctl add-br ovs-sriov
+
+# Enable hardware offload (disabled by default).
+ovs-vsctl set Open_vSwitch . other_config:hw-offload=true
+
+# The aging timeout of OVS is given is ms and can be controlled with this command:
+ovs-vsctl set Open_vSwitch . other_config:max-idle=30000
+
+# check the result
+ovs-vsctl get Open_vSwitch . other_config
+
+# Restart the openvswitch service. This step is required for HW offload changes to take effect.
+systemctl restart openvswitch-switch.service
+
+
+# Make sure to bring up the PF and representor netdevices.
+ovs-vsctl add-port ovs-sriov rdma0
+ovs-vsctl add-port ovs-sriov rdma0_0
+
+# show something
+ovs-vsctl list-ports ovs-sriov
+ovs-dpctl show
+
+
+# sudo ovs-appctl dpctl/dump-flows type=all -m
+# This will give results like below. All type of flows are displayed!
+# recirc_id(0),in_port(2),eth(src=02:49:61:d4:70:e8,dst=02:bc:b6:ff:bf:97),eth_type(0x0800),ipv4(frag=no), packets:584316, bytes:36666200, used:4.940s, actions:3
+# recirc_id(0),in_port(2),eth(src=02:49:61:d4:70:e8,dst=02:bc:b6:ff:bf:97),eth_type(0x0806), packets:0, bytes:0, used:3.110s, actions:3
+# recirc_id(0),in_port(3),eth(src=02:bc:b6:ff:bf:97,dst=02:49:61:d4:70:e8),eth_type(0x0800),ipv4(frag=no), packets:29461402, bytes:34366302886, used:4.940s, actions:2
+# recirc_id(0),in_port(3),eth(src=02:bc:b6:ff:bf:97,dst=02:49:61:d4:70:e8),eth_type(0x0806), packets:2, bytes:120, used:2.090s, actions:2
+# recirc_id(0),in_port(3),eth(src=1c:34:da:a5:55:94,dst=01:80:c2:00:00:0e),eth_type(0x88cc), packets:0, bytes:0, used:4.340s, actions:drop
+# recirc_id(0),in_port(3),eth(src=0c:42:a1:ef:1b:06,dst=ff:ff:ff:ff:ff:ff),eth_type(0x0806),arp(sip=192.168.211.162,tip=192.168.211.2,op=1/0xff), packets:2120, bytes:127200, used:0.141s, actions:1,2
+# recirc_id(0),in_port(3),eth(src=0c:42:a1:ef:1a:4e,dst=ff:ff:ff:ff:ff:ff),eth_type(0x0806),arp(sip=192.168.211.130,tip=192.168.211.2,op=1/0xff), packets:2121, bytes:127260, used:0.633s, actions:1,2
+# recirc_id(0),in_port(3),eth(src=0c:42:a1:ef:1b:5a,dst=ff:ff:ff:ff:ff:ff),eth_type(0x0806),arp(sip=192.168.211.194,tip=192.168.211.2,op=1/0xff), packets:2120, bytes:127200, used:0.401s, actions:1,2
+# recirc_id(0),in_port(3),eth(src=0c:42:a1:ef:1b:26,dst=ff:ff:ff:ff:ff:ff),eth_type(0x0806),arp(sip=192.168.211.34,tip=192.168.211.2,op=1/0xff), packets:3120, bytes:187200, used:0.721s, actions:1,2
+# recirc_id(0),in_port(3),eth(src=0c:42:a1:ef:1a:4a,dst=ff:ff:ff:ff:ff:ff),eth_type(0x0806),arp(sip=192.168.211.66,tip=192.168.211.2,op=1/0xff), packets:2118, bytes:127080, used:0.845s, actions:1,2


### PR DESCRIPTION
One major uncertainty is that I was not sure is whether ovs dump-flows can give sufficient information and work with all kinds of flows, including hardware offloaded flows. Now it seems all good!

I setup two cpu vms and tested with `iperf` and `ib_write_bw`. The bandwidth is good. Rate limiting works. The flow table looks like this.
```python
$ # This will give results like below. All type of flows are displayed!
$ sudo ovs-appctl dpctl/dump-flows type=all -m
recirc_id(0),in_port(2),eth(src=02:49:61:d4:70:e8,dst=02:bc:b6:ff:bf:97),eth_type(0x0800),ipv4(frag=no), packets:584316, bytes:36666200, used:4.940s, actions:3
recirc_id(0),in_port(2),eth(src=02:49:61:d4:70:e8,dst=02:bc:b6:ff:bf:97),eth_type(0x0806), packets:0, bytes:0, used:3.110s, actions:3
recirc_id(0),in_port(3),eth(src=02:bc:b6:ff:bf:97,dst=02:49:61:d4:70:e8),eth_type(0x0800),ipv4(frag=no), packets:29461402, bytes:34366302886, used:4.940s, actions:2
recirc_id(0),in_port(3),eth(src=02:bc:b6:ff:bf:97,dst=02:49:61:d4:70:e8),eth_type(0x0806), packets:2, bytes:120, used:2.090s, actions:2
recirc_id(0),in_port(3),eth(src=1c:34:da:a5:55:94,dst=01:80:c2:00:00:0e),eth_type(0x88cc), packets:0, bytes:0, used:4.340s, actions:drop
recirc_id(0),in_port(3),eth(src=0c:42:a1:ef:1b:06,dst=ff:ff:ff:ff:ff:ff),eth_type(0x0806),arp(sip=192.168.211.162,tip=192.168.211.2,op=1/0xff), packets:2120, bytes:127200, used:0.141s, actions:1,2
recirc_id(0),in_port(3),eth(src=0c:42:a1:ef:1a:4e,dst=ff:ff:ff:ff:ff:ff),eth_type(0x0806),arp(sip=192.168.211.130,tip=192.168.211.2,op=1/0xff), packets:2121, bytes:127260, used:0.633s, actions:1,2
recirc_id(0),in_port(3),eth(src=0c:42:a1:ef:1b:5a,dst=ff:ff:ff:ff:ff:ff),eth_type(0x0806),arp(sip=192.168.211.194,tip=192.168.211.2,op=1/0xff), packets:2120, bytes:127200, used:0.401s, actions:1,2
recirc_id(0),in_port(3),eth(src=0c:42:a1:ef:1b:26,dst=ff:ff:ff:ff:ff:ff),eth_type(0x0806),arp(sip=192.168.211.34,tip=192.168.211.2,op=1/0xff), packets:3120, bytes:187200, used:0.721s, actions:1,2
recirc_id(0),in_port(3),eth(src=0c:42:a1:ef:1a:4a,dst=ff:ff:ff:ff:ff:ff),eth_type(0x0806),arp(sip=192.168.211.66,tip=192.168.211.2,op=1/0xff), packets:2118, bytes:127080, used:0.845s, actions:1,2

```